### PR TITLE
Added new api for register loan

### DIFF
--- a/case/common.py
+++ b/case/common.py
@@ -1,5 +1,4 @@
 from django.db import models
-
 from authentication.models import User
 from case.enums import CommitmentTypeChoices, PlanChoices
 from case.models import Adverse

--- a/case/serializers.py
+++ b/case/serializers.py
@@ -3,6 +3,7 @@ from rest_framework import serializers
 
 from common.enums import UserTypeChoices, RoleChoices
 from organization.models import Organization, OrganizationUser
+from .common import RegisterLoan, PaymentCommitment, PropertyRepossessed, Bankrupt
 from .models import (
     Case,
     Files,
@@ -604,3 +605,36 @@ class AdverseSerializer(serializers.ModelSerializer):
             "updated_by",
             "user",
         ]
+
+# Serializer for RegisterLoan..
+class RegisterLoanSerializer(serializers.ModelSerializer):
+    created_at = CommonUserWithIdSerializer(read_only=True)
+    updated_at = CommonUserWithIdSerializer(read_only=True)
+
+    class Meta:
+        model = RegisterLoan
+        fields =[
+            "alias",
+            "adverse",
+            "amount",
+            "loan_company_name",
+            "date_registered",
+            "has_satisfied",
+            "date_satisfied",
+            "created_at",
+            "updated_at",
+            "created_by",
+            "updated_by",
+            "user_ip",
+        ]
+        read_only_fields = [
+            "alias",
+            "adverse",
+            "created_at",
+            "updated_at",
+            "created_by",
+            "updated_by",
+            "user_ip",
+        ]
+
+

--- a/case/urls.py
+++ b/case/urls.py
@@ -22,7 +22,7 @@ from .views import (
     EmploymentDetailsCreateApiView,
     EmploymentDetailsRetrieveUpdateApiView,
     AdverseListApiView,
-    AdverseRetrieveUpdateApiView,
+    AdverseRetrieveUpdateApiView, RegisterLoanListCreateApiView,
 )
 
 urlpatterns = [
@@ -122,11 +122,11 @@ urlpatterns = [
         AdverseRetrieveUpdateApiView.as_view(),
         name="adverse-detail",
     ),
-    # path(
-    #     "<uuid:case_alias>/adverse/<uuid:alias>/register/loans/",
-    #     RegisterLoanListCreateApiView.as_view(),
-    #     name="register-loan-list-create",
-    # ),
+    path(
+        "<uuid:case_alias>/adverse/<uuid:alias>/register/loans/",
+        RegisterLoanListCreateApiView.as_view(),
+        name="register-loan-list-create",
+    ),
     # path(
     #     "<uuid:case_alias>/adverse/<uuid:alias>/payment/commitments/",
     #     PaymentCommitmentListCreateApiView.as_view(),

--- a/case/views.py
+++ b/case/views.py
@@ -16,6 +16,7 @@ from rest_framework.response import Response
 from authentication.models import User
 from common.serializers import CommonUserSerializer, CommonUserWithIdSerializer
 from organization.models import Organization
+from .common import RegisterLoan, PaymentCommitment, PropertyRepossessed
 from .filter import CaseFilter, FileFilter
 from .models import (
     Case,
@@ -42,6 +43,8 @@ from .serializers import (
     DirectorShareholderSerializer,
     EmploymentDetailsSerializer,
     AdverseSerializer,
+    RegisterLoanSerializer,
+
 )
 
 
@@ -502,3 +505,20 @@ class AdverseRetrieveUpdateApiView(RetrieveUpdateAPIView):
 
     def perform_update(self, serializer):
         serializer.save(updated_by=self.request.user)
+
+# views for RegisterLoan
+class RegisterLoanListCreateApiView(ListCreateAPIView):
+    serializer_class = RegisterLoanSerializer
+    permission_classes = [IsAuthenticated]
+
+    def get_queryset(self):
+        alias = self.kwargs.get("alias")
+        return RegisterLoan.objects.filter(adverse__alias=alias)
+
+    def perform_create(self, serializer):
+        alias = self.kwargs["alias"]
+        adverse = get_object_or_404(Adverse, alias=alias)
+        serializer.save(adverse=adverse, created_by=self.request.user)
+
+
+


### PR DESCRIPTION
Adds RegisterLoan serializer and RegisterLoan Views for case API.
This is urls path(
        "<uuid:case_alias>/adverse/<uuid:alias>/register/loans/",
        RegisterLoanListCreateApiView.as_view(),
        name="register-loan-list-create",
    ),